### PR TITLE
fixes #5 Use the new obs-frontend-api to log start/stop

### DIFF
--- a/DLLProject/OBSInfoWriter.vcxproj
+++ b/DLLProject/OBSInfoWriter.vcxproj
@@ -46,7 +46,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v120</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
@@ -97,6 +97,7 @@
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>libGroundfloor.lib;obs.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -124,12 +125,15 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>$(SolutionDir)Crosscables\include;$(SolutionDir)..\..\GitHub\obs-studio\libobs</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)..\AudacityRover\lib\Crosscables\include;$(SolutionDir)..\obs-studio\libobs;$(SolutionDir)..\obs-studio\UI</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_WINDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>libGroundfloor.lib;obs.lib;obs-frontend-api.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(SolutionDir)..\AudacityRover\lib\Crosscables\x64\Release;$(SolutionDir)..\obs-studio\VSProject\libobs\Release;$(SolutionDir)..\obs-studio\UI\obs-frontend-api\Release;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/InfoWriter.h
+++ b/InfoWriter.h
@@ -1,20 +1,8 @@
 #pragma once
 
-#ifndef FAKEOBS
-#include <obs.hpp>
-#else
-typedef void* calldata_t;
-
-class OBSSignal
-{
-public:
-   void Connect(void *handler_, const char *signal_, void *callback_, void *param_)
-   {
-   }
-};
-#endif
-
 #include "InfoWriterSettings.h"
+
+enum InfoMediaType { imtUnknown = 0, imtStream = 1, imtRecording = 2 };
 
 class InfoWriter
 {
@@ -23,21 +11,15 @@ private:
    InfoWriterSettings Settings;
    bool Started;
 
-   OBSSignal OutputStarting;
-   OBSSignal OutputStopping;
-
-   static void OnOutputStarting(void *data, calldata_t *calldata);
-   static void OnOutputStopping(void *param, calldata_t *calldata);
-
    std::string InfoWriter::SecsToHMSString(__int64 totalseconds);
    std::string MilliToHMSString(__int64 time);
    void WriteToFile(std::string Data);
 public:
    InfoWriter();
 
-   void MarkStart();
+   void MarkStart(InfoMediaType AType);
    void WriteInfo();
-   void MarkStop();
+   void MarkStop(InfoMediaType AType);
 
    bool HasStarted();
 

--- a/TestConsoleProject/OBSInfoWriterTestConsole.vcxproj
+++ b/TestConsoleProject/OBSInfoWriterTestConsole.vcxproj
@@ -47,7 +47,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v120</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
@@ -121,13 +121,15 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>$(SolutionDir)Crosscables/include;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)..\..\GitHub\AudacityRover\lib\Crosscables\include;$(SolutionDir)..\..\GitHub\obs-studio\libobs</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalLibraryDirectories>$(SolutionDir)extlibs;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(SolutionDir)..\AudacityRover\lib\Crosscables\x64\Release;$(SolutionDir)..\obs-studio\VSProject\libobs\Release;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>obs.lib;libGroundfloor.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/main.cpp
+++ b/main.cpp
@@ -9,7 +9,7 @@ int main()
    Writer.GetSettings()->SetFilename("c:/temp/log.txt");
    Writer.GetSettings()->SetFormat("%d:%02d:%02d");
    
-   Writer.MarkStart();
+   Writer.MarkStart(imtUnknown);
 
    Writer.WriteInfo();
 
@@ -21,7 +21,7 @@ int main()
 
    Writer.WriteInfo();
 
-   Writer.MarkStop();
+   Writer.MarkStop(imtUnknown);
 
 
    return 0;


### PR DESCRIPTION
also removes old experimental signal handler code that was never implemented in OBS, and logs different text depending on if stream or recording was started or stopped