### PR TITLE
Updated to work with OBS pause, and add separate timers for stream and record.

### DIFF
--- a/Build.md
+++ b/Build.md
@@ -22,6 +22,29 @@
   - Run lib /def:obsfrontend.exports /out:obs-frontend-api32.lib /machine:x86
 - Copy the lib files to ..\obs-studio-bin\lib\x64 and ..\obs-studio-bin\lib\x86 from the OBSInfoWriter folder
 
+4.ALT. Another way to do step 4 above for Windows
+- Make .lib files for obs.dll and obs-frontend-api.dll
+  - Open visual studio command prompt and copy obs.dll and obs-frontend-api.dll to a folder (no spaces in path)
+  - Create a .bat file (make sure to execute in the visual studio command prompt) as follows
+
+@echo off
+dumpbin /exports obs.dll > exports.txt
+echo EXPORTS > obs.def
+for /f "skip=19 tokens=4" %%A in (exports.txt) do echo %%A >> obs.def
+lib /def:obs.def /out:obs32.lib /machine:x86
+lib /def:obs.def /out:obs64.lib /machine:x64
+
+@echo off
+dumpbin /exports obs-frontend-api.dll > exports.txt
+echo EXPORTS > obs-frontend-api.def
+for /f "skip=19 tokens=4" %%A in (exports.txt) do echo %%A >> obs-frontend-api.def
+lib /def:obs-frontend-api.def /out:obs-frontend-api32.lib /machine:x86
+lib /def:obs-frontend-api.def /out:obs-frontend-api64.lib /machine:x64
+  
+  - Run the batfile an you should have the 4 lib files made
+- Copy the lib files to ..\obs-studio-bin\lib\x64 and ..\obs-studio-bin\lib\x86 from the OBSInfoWriter folder 
+  - I believe the files need to be renamed obs-frontend-api.lib and obs.lib under the \x86 and \x64 folders
+ 
 5. On Linux:
 - No extra action required
 
@@ -38,3 +61,5 @@
 5. Build
 - Linux: make -f Makefile.linux
 - Mac: make -f Makefile.mac
+
+

--- a/Build.md
+++ b/Build.md
@@ -27,24 +27,27 @@
   - Open visual studio command prompt and copy obs.dll and obs-frontend-api.dll to a folder (no spaces in path)
   - Create a .bat file (make sure to execute in the visual studio command prompt) as follows
 
+```
 @echo off
 dumpbin /exports obs.dll > exports.txt
 echo EXPORTS > obs.def
 for /f "skip=19 tokens=4" %%A in (exports.txt) do echo %%A >> obs.def
 lib /def:obs.def /out:obs32.lib /machine:x86
 lib /def:obs.def /out:obs64.lib /machine:x64
-
+```
+```
 @echo off
 dumpbin /exports obs-frontend-api.dll > exports.txt
 echo EXPORTS > obs-frontend-api.def
 for /f "skip=19 tokens=4" %%A in (exports.txt) do echo %%A >> obs-frontend-api.def
 lib /def:obs-frontend-api.def /out:obs-frontend-api32.lib /machine:x86
 lib /def:obs-frontend-api.def /out:obs-frontend-api64.lib /machine:x64
-  
-  - Run the batfile an you should have the 4 lib files made
-- Copy the lib files to ..\obs-studio-bin\lib\x64 and ..\obs-studio-bin\lib\x86 from the OBSInfoWriter folder 
+```
+
+  - Run the .bat files and you should have the 4 lib files made
+  - Copy the lib files to ..\obs-studio-bin\lib\x64 and ..\obs-studio-bin\lib\x86 from the OBSInfoWriter folder
   - I believe the files need to be renamed obs-frontend-api.lib and obs.lib under the \x86 and \x64 folders
- 
+
 5. On Linux:
 - No extra action required
 
@@ -61,5 +64,3 @@ lib /def:obs-frontend-api.def /out:obs-frontend-api64.lib /machine:x64
 5. Build
 - Linux: make -f Makefile.linux
 - Mac: make -f Makefile.mac
-
-

--- a/InfoWriter.h
+++ b/InfoWriter.h
@@ -4,15 +4,26 @@
 #include <cstdint>
 #include <Groundfloor/Molecules/String.h>
 
-enum InfoMediaType { imtUnknown = 0, imtStream = 1, imtRecording = 2 };
+enum InfoMediaType { imtUnknown = 0, imtStream = 1, imtRecording = 2, 
+					 imtRecordingPauseStart = 3, imtRecordingPauseResume = 4
+};
 typedef int8_t InfoHotkey;
 
 class InfoWriter
 {
 private:
    int64_t StartTime;
+   int64_t StartRecordTime;
+   int64_t StartStreamTime;
+   int64_t PausedTotalTime;
+   int64_t PausedStartTime;
+
    InfoWriterSettings Settings;
-   bool Started;
+   bool StreamStarted;
+   bool RecordStarted;  
+   bool ShowStreaming;
+   bool Paused;
+
    std::string CurrentFilename;
 
    void InitCurrentFilename(int64_t timestamp);
@@ -25,11 +36,18 @@ public:
    InfoWriter();
 
    void MarkStart(const InfoMediaType AType);
+   void MarkPauseStart(InfoMediaType AType);
+   void MarkPauseResume(InfoMediaType AType);
    void WriteInfo(const std::string AExtraInfo) const;
    void WriteInfo(const InfoHotkey AHotkey) const;
    void MarkStop(const InfoMediaType AType);
 
    bool HasStarted() const;
+   bool IsStreaming() const;
+   bool ShowStreamOutput() const;
+   void SetShowStreamOutput(bool logchanges);
+
+   std::string NowTimeStamp() const;
 
    InfoWriterSettings *GetSettings();
 };

--- a/InfoWriterSettings.cpp
+++ b/InfoWriterSettings.cpp
@@ -36,6 +36,11 @@ bool InfoWriterSettings::GetShouldLogSceneChanges() const
 	return ShouldLogSceneChanges;
 }
 
+bool InfoWriterSettings::GetShouldLogStreaming() const
+{
+	return ShouldLogStreaming;
+}
+
 void InfoWriterSettings::SetFilename(std::string filename)
 {
    this->Filename = filename;
@@ -68,4 +73,9 @@ void InfoWriterSettings::SetHotkeyText(const int hotkeynum, std::string text)
 void InfoWriterSettings::SetShouldLogSceneChanges(bool logchanges)
 {
 	ShouldLogSceneChanges = logchanges;
+}
+
+void InfoWriterSettings::SetShouldLogStreaming(bool logchanges)
+{
+	ShouldLogStreaming = logchanges;
 }

--- a/InfoWriterSettings.h
+++ b/InfoWriterSettings.h
@@ -23,16 +23,20 @@ protected:
    std::string Hotkey13Text;
    std::string Hotkey14Text;
 
-
    bool ShouldLogSceneChanges;
+   bool ShouldLogStreaming;
+
 public:
    std::string GetFilename() const;
    std::string GetFormat() const;
    std::string GetHotkeyText(const int hotkeynum) const;
+
    bool GetShouldLogSceneChanges() const;
+   bool GetShouldLogStreaming() const;
 
    void SetFilename(std::string filename);
    void SetFormat(std::string format);
    void SetHotkeyText(const int hotkeynum, std::string text);
    void SetShouldLogSceneChanges(bool logchanges);
+   void SetShouldLogStreaming(bool logchanges);
 };

--- a/README.md
+++ b/README.md
@@ -44,14 +44,14 @@ What is possible that might improve logging is that you can put spaces or a \t t
 Contributed by https://github.com/RetroGamer74
 ![Hotkeys List Sample](sample_hotkeys_list.jpg)
 
-######### NEW CHANGES (TheTawnyFool)
+#### NEW CHANGES (TheTawnyFool)
     Contributed by https://github.com/TheTawnyFool
 
     Changed the output to log seperate timers for recording and streaming. Allows for indepedent timestamps of streaming and recordings at the same time. 
 
     Updated to fix problems with OBS newer update to allow pausing in recordings.  Now when you pause a recording, the recording timer used by the hotkeys will pause until you resume the recording.  This way the record timer offsets of the hotkey events to be synced correctly with the video. The streaming timer will not pause if you are tracking both.
 
-    ## Checkbox to log streaming events
+## Checkbox to log streaming events
       Allows turning on and off logging relating to streaming. Recommend to leave off if not streaming, and or not wanting to log timers relating to streaming.
 
 

--- a/README.md
+++ b/README.md
@@ -42,5 +42,18 @@ What is possible that might improve logging is that you can put spaces or a \t t
 ## More hotkeys
 
 Contributed by https://github.com/RetroGamer74
-
 ![Hotkeys List Sample](sample_hotkeys_list.jpg)
+
+######### NEW CHANGES (TheTawnyFool)
+    Contributed by https://github.com/TheTawnyFool
+
+    Changed the output to log seperate timers for recording and streaming. Allows for indepedent timestamps of streaming and recordings at the same time. 
+
+    Updated to fix problems with OBS newer update to allow pausing in recordings.  Now when you pause a recording, the recording timer used by the hotkeys will pause until you resume the recording.  This way the record timer offsets of the hotkey events to be synced correctly with the video. The streaming timer will not pause if you are tracking both.
+
+    ## Checkbox to log streaming events
+      Allows turning on and off logging relating to streaming. Recommend to leave off if not streaming, and or not wanting to log timers relating to streaming.
+
+
+
+


### PR DESCRIPTION
  Hi, this is my first time working on a project in github.  Please let me know if I'm not doing anything in a way that is incorrect or considered inappropriate.  

## Changed timers
     Changed the output to log separate timers for recording and streaming. Allows for independent timestamps of streaming and recordings at the same time. 

## Update for OBS pause functionality
     Updated to fix problems with OBS update to allow pausing in recordings.  Now when you pause a recording, the recording timer used by the hotkeys will pause until you resume the recording.  This way the record timer offsets of the hotkey events to be synced correctly with the video. The streaming timer will not pause if you are tracking both.

## Checkbox to log streaming events
      Allows turning on and off logging relating to streaming. Recommend to leave off if not streaming, and or not wanting to log timers relating to streaming.