### PR TITLE
Ignore intermediate files that appeared recently

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ x86/
 bld/
 [Bb]in/
 [Oo]bj/
+.deps/
+cmake/.CMakeBuildNumber
 
 # Visual Studio 2015 cache/options directory
 .vs/


### PR DESCRIPTION
These files were not generated before recent changes in build workflow for OBS 2.9 (delivered 2023-10-27).