### PR TITLE
Fixed error: ‘uint32_t’ was not declared in this scope

### DIFF
--- a/OutputFormat/OutputFormat.Default.cpp
+++ b/OutputFormat/OutputFormat.Default.cpp
@@ -3,6 +3,7 @@
 #include <Groundfloor/Materials/FileWriter.h>
 #include <regex>
 #include <cmath>
+#include <cstdint>
 
 const char *c_OutputDefaultTimestampNotation = "%Y-%m-%d %H:%M:%S";
 

--- a/OutputFormat/OutputFormat.EDL.cpp
+++ b/OutputFormat/OutputFormat.EDL.cpp
@@ -2,6 +2,7 @@
 #include <Groundfloor/Materials/FileWriter.h>
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 
 const int reelnameMaxlength = 5;
 


### PR DESCRIPTION
Fixed a compilation error on Manjaro Linux, with gcc version 13.2.1. Likely to happen on any distro with a recent enough gcc version.