### PR TITLE
Millisecond precision timing and format validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ bld/
 .deps/
 cmake/.CMakeBuildNumber
 build_x86_64/
+build_test/
 
 # Visual Studio 2015 cache/options directory
 .vs/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,9 +104,10 @@ if(BUILD_TESTS)
     InfoWriter.cpp
     InfoWriterSettings.cpp
     DummyUtils.cpp
+    DummyPlatform.cpp
   )
   target_compile_features(test_infowriter PRIVATE cxx_std_17)
-  target_include_directories(test_infowriter PRIVATE ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR}/_deps/crosscables-src)
+  target_include_directories(test_infowriter PRIVATE ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR}/_deps/crosscables-src ${CMAKE_SOURCE_DIR}/tests/stubs)
   FetchContent_Declare(Catch2 GIT_REPOSITORY https://github.com/catchorg/Catch2.git GIT_TAG v3.5.0)
   FetchContent_MakeAvailable(Catch2)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,7 @@ target_sources(
     InfoWriter.cpp
     InfoWriterSettings.cpp
     InfoWriterObsUtils.cpp
+    FormatUtils.cpp
     OBSStudioInfoWriter.cpp
 )
 
@@ -97,12 +98,14 @@ if(BUILD_TESTS)
   add_executable(
     test_infowriter
     tests/test_filename_format.cpp
+    tests/test_format_utils.cpp
     OutputFormat/OutputFormat.SRT.cpp
     OutputFormat/OutputFormat.CSV.cpp
     OutputFormat/OutputFormat.EDL.cpp
     OutputFormat/OutputFormat.Default.cpp
     InfoWriter.cpp
     InfoWriterSettings.cpp
+    FormatUtils.cpp
     DummyUtils.cpp
     DummyPlatform.cpp
   )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,7 +110,10 @@ if(BUILD_TESTS)
     DummyPlatform.cpp
   )
   target_compile_features(test_infowriter PRIVATE cxx_std_17)
-  target_include_directories(test_infowriter PRIVATE ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR}/_deps/crosscables-src ${CMAKE_SOURCE_DIR}/tests/stubs)
+  target_include_directories(
+    test_infowriter
+    PRIVATE ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR}/_deps/crosscables-src ${CMAKE_SOURCE_DIR}/tests/stubs
+  )
   FetchContent_Declare(Catch2 GIT_REPOSITORY https://github.com/catchorg/Catch2.git GIT_TAG v3.5.0)
   FetchContent_MakeAvailable(Catch2)
 

--- a/DummyPlatform.cpp
+++ b/DummyPlatform.cpp
@@ -1,0 +1,11 @@
+#include <chrono>
+#include <cstdint>
+
+extern "C" {
+
+uint64_t os_gettime_ns(void)
+{
+	auto now = std::chrono::steady_clock::now();
+	return (uint64_t)std::chrono::duration_cast<std::chrono::nanoseconds>(now.time_since_epoch()).count();
+}
+}

--- a/DummyUtils.cpp
+++ b/DummyUtils.cpp
@@ -4,3 +4,8 @@ std::optional<std::string> get_filename_from_recording_path([[maybe_unused]] con
 {
 	return std::nullopt;
 }
+
+std::optional<std::string> get_filename_from_last_recording([[maybe_unused]] const InfoWriterSettings &Settings)
+{
+	return std::nullopt;
+}

--- a/FormatUtils.cpp
+++ b/FormatUtils.cpp
@@ -1,0 +1,53 @@
+#include "FormatUtils.h"
+#include <cmath>
+#include <cstdio>
+#include <regex>
+
+bool HasUnsafeFormatSpecifiers(const std::string &format)
+{
+	// Reject format specifiers that expect non-integer arguments
+	// since we only pass uint32_t values to sprintf.
+	// Matches: %s, %n, %p, %f, %e, %g, %a (and uppercase variants)
+	// while allowing flags, width, and precision between % and the specifier.
+	std::regex unsafe_regex("%[^%]*[snpfFeEgGaA]");
+	return std::regex_search(format, unsafe_regex);
+}
+
+int CountFormatSpecifiers(const std::string &format)
+{
+	// Count printf format specifiers, excluding %% (literal percent)
+	// First remove all %% so they don't interfere with matching
+	std::string cleaned = std::regex_replace(format, std::regex("%%"), "");
+	std::regex specifier_regex("%[^%]*[diouxXcnspeEfFgGaA]");
+	auto begin = std::sregex_iterator(cleaned.begin(), cleaned.end(), specifier_regex);
+	auto end = std::sregex_iterator();
+	return (int)std::distance(begin, end);
+}
+
+static const int MaxFormatSpecifiers = 4; // hr, min, sec, zzz
+
+std::string FormatMillisToHMS(const std::string &format, int64_t totalmilliseconds)
+{
+	if (HasUnsafeFormatSpecifiers(format))
+		return format;
+
+	if (CountFormatSpecifiers(format) > MaxFormatSpecifiers)
+		return format;
+
+	int64_t totalseconds = totalmilliseconds / 1000;
+	uint32_t hr = (uint32_t)trunc(totalseconds / 60.0 / 60.0);
+	uint32_t min = (uint32_t)trunc(totalseconds / 60.0) - (hr * 60);
+	uint32_t sec = totalseconds % 60;
+	uint32_t zzz = totalmilliseconds % 1000;
+
+	std::string fmt = format;
+	std::string replacement = "\t";
+	std::regex tabregex("(\\\\t)");
+	fmt = std::regex_replace(fmt, tabregex, replacement);
+	fmt += "\0\0\0\0";
+
+	char buffer[1024];
+	sprintf(&buffer[0], fmt.c_str(), hr, min, sec, zzz);
+
+	return buffer;
+}

--- a/FormatUtils.h
+++ b/FormatUtils.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+std::string FormatMillisToHMS(const std::string &format, int64_t totalmilliseconds);
+bool HasUnsafeFormatSpecifiers(const std::string &format);
+int CountFormatSpecifiers(const std::string &format);

--- a/InfoWriter.cpp
+++ b/InfoWriter.cpp
@@ -47,6 +47,26 @@ std::string InfoWriter::SecsToHMSString(const int64_t totalseconds) const
 	return buffer;
 }
 
+std::string InfoWriter::SecsToHMSSzzztring(const std::chrono::duration<double> totalseconds) const
+{
+	uint32_t just_seconds = trunc(totalseconds.count());
+	uint32_t hr = (uint32_t)trunc(just_seconds / 60.0 / 60.0);
+	uint32_t min = (uint32_t)trunc(just_seconds / 60.0) - (hr * 60);
+	uint32_t sec = just_seconds % 60;
+	uint32_t zzz = (uint32_t)trunc((totalseconds.count() - just_seconds) * 1000.0);
+
+	std::string format = Settings.GetFormat();
+	std::string replacement = "\t";
+	std::regex tabregex("(\\\\t)");
+	format = std::regex_replace(format, tabregex, replacement);
+	format += "\0\0\0\0";
+
+	char buffer[1024];
+	sprintf(&buffer[0], format.c_str(), hr, min, sec, zzz);
+
+	return buffer;
+}
+
 int64_t InfoWriter::getPausedTime(const int64_t currentTime) const
 {
 	auto PausedTmpTime = PausedTotalTime;
@@ -182,6 +202,8 @@ void InfoWriter::InitCurrentFilename()
 void InfoWriter::MarkStart(InfoMediaType AType)
 {
 	StartTime = Groundfloor::GetTimestamp();
+	StartTimePoint = std::chrono::steady_clock::now();
+
 	InitCurrentFilename();
 
 	auto outputformat = Settings.GetOutputFormat();
@@ -204,7 +226,7 @@ void InfoWriter::MarkStart(InfoMediaType AType)
 	switch (AType) {
 	case imtStream:
 		StartStreamTime = StartTime;
-		StreamStarted = true;
+		StartStreamTimePoint = StartTimePoint;
 		if (this->Settings.GetShouldLogStreaming()) {
 			MarkStr->prepend_ansi("EVENT:START STREAM @ ");
 		}
@@ -216,6 +238,7 @@ void InfoWriter::MarkStart(InfoMediaType AType)
 	case imtRecording:
 		MarkStr->prepend_ansi("EVENT:START RECORDING @ ");
 		StartRecordTime = StartTime;
+		StartRecordTimePoint = StartTimePoint;
 		RecordStarted = true;
 		Paused = false;
 		output->TextMarker(MarkStr->getValue());

--- a/InfoWriter.cpp
+++ b/InfoWriter.cpp
@@ -3,9 +3,7 @@
 #include <Groundfloor/Atoms/Defines.h>
 #include <Groundfloor/Materials/Functions.h>
 #include <cstdint>
-#include <cmath>
 #include <memory>
-#include <regex>
 
 #include "OutputFormat/OutputFormat.Default.h"
 #include "OutputFormat/OutputFormat.EDL.h"
@@ -13,8 +11,10 @@
 #include "OutputFormat/OutputFormat.SRT.h"
 
 #include "InfoWriterObsUtils.h"
+#include "FormatUtils.h"
 
 #include <util/platform.h>
+#include <util/base.h>
 
 const char *c_TimestampNotation = "%Y-%m-%d %H:%M:%S";
 
@@ -33,22 +33,7 @@ InfoWriter::InfoWriter() : Settings()
 
 std::string InfoWriter::MillisToHMSString(const int64_t totalmilliseconds) const
 {
-	int64_t totalseconds = totalmilliseconds / 1000;
-	uint32_t hr = (uint32_t)trunc(totalseconds / 60.0 / 60.0);
-	uint32_t min = (uint32_t)trunc(totalseconds / 60.0) - (hr * 60);
-	uint32_t sec = totalseconds % 60;
-	uint32_t zzz = totalmilliseconds % 1000;
-
-	std::string format = Settings.GetFormat();
-	std::string replacement = "\t";
-	std::regex tabregex("(\\\\t)");
-	format = std::regex_replace(format, tabregex, replacement);
-	format += "\0\0\0\0";
-
-	char buffer[1024];
-	sprintf(&buffer[0], format.c_str(), hr, min, sec, zzz);
-
-	return buffer;
+	return FormatMillisToHMS(Settings.GetFormat(), totalmilliseconds);
 }
 
 uint64_t InfoWriter::getPausedTimeNs(const uint64_t currentTimeNs) const
@@ -184,9 +169,14 @@ void InfoWriter::InitCurrentFilename()
 	if (!currentname_set) {
 		CurrentFilename = Settings.GetFilename();
 		if (CurrentFilename.find('%') != 0) {
-			auto filename = Groundfloor::TimestampToStr(CurrentFilename.c_str(), StartTime);
-			CurrentFilename = filename->getValue();
-			delete filename;
+			try {
+				auto filename = Groundfloor::TimestampToStr(CurrentFilename.c_str(), StartTime);
+				CurrentFilename = filename->getValue();
+				delete filename;
+			} catch (const std::runtime_error &e) {
+				blog(LOG_ERROR, "[OBSInfoWriter] Invalid filename format: %s", e.what());
+				CurrentFilename = Settings.GetFilename();
+			}
 		}
 	}
 }

--- a/InfoWriter.cpp
+++ b/InfoWriter.cpp
@@ -201,6 +201,23 @@ void InfoWriter::InitCurrentFilename()
 	}
 }
 
+bool InfoWriter::RenameCurrentFile(const std::string &newFilename)
+{
+	if (CurrentFilename.empty() || newFilename.empty())
+		return false;
+
+	if (CurrentFilename == newFilename)
+		return false;
+
+	std::error_code ec;
+	std::filesystem::rename(CurrentFilename, newFilename, ec);
+	if (ec)
+		return false;
+
+	CurrentFilename = newFilename;
+	return true;
+}
+
 void InfoWriter::MarkStart(InfoMediaType AType)
 {
 	StartTime = Groundfloor::GetTimestamp();
@@ -293,6 +310,12 @@ void InfoWriter::MarkStop(InfoMediaType AType)
 	}
 
 	WriteInfo(MarkStr->getValue());
+
+	if (AType == imtRecording && Settings.GetShouldSyncNameAndPathWithVideo()) {
+		auto lastRecording = get_filename_from_last_recording(Settings);
+		if (lastRecording)
+			RenameCurrentFile(lastRecording.value());
+	}
 
 	if (!IsStreaming() && !IsRecording()) {
 		output = nullptr;

--- a/InfoWriter.cpp
+++ b/InfoWriter.cpp
@@ -14,46 +14,30 @@
 
 #include "InfoWriterObsUtils.h"
 
+#include <util/platform.h>
+
 const char *c_TimestampNotation = "%Y-%m-%d %H:%M:%S";
 
 InfoWriter::InfoWriter() : Settings()
 {
 	lastInfoMediaType = imtUnknown;
 	StartTime = 0;
-	StartRecordTime = 0;
-	StartStreamTime = 0;
-	PausedTotalTime = 0;
-	PausedStartTime = 0;
+	StartRecordTimeNs = 0;
+	StartStreamTimeNs = 0;
+	PausedTotalTimeNs = 0;
+	PausedStartTimeNs = 0;
 	StreamStarted = false;
 	RecordStarted = false;
 	Paused = false;
 }
 
-std::string InfoWriter::SecsToHMSString(const int64_t totalseconds) const
+std::string InfoWriter::MillisToHMSString(const int64_t totalmilliseconds) const
 {
+	int64_t totalseconds = totalmilliseconds / 1000;
 	uint32_t hr = (uint32_t)trunc(totalseconds / 60.0 / 60.0);
 	uint32_t min = (uint32_t)trunc(totalseconds / 60.0) - (hr * 60);
 	uint32_t sec = totalseconds % 60;
-
-	std::string format = Settings.GetFormat();
-	std::string replacement = "\t";
-	std::regex tabregex("(\\\\t)");
-	format = std::regex_replace(format, tabregex, replacement);
-	format += "\0\0\0\0";
-
-	char buffer[1024];
-	sprintf(&buffer[0], format.c_str(), hr, min, sec);
-
-	return buffer;
-}
-
-std::string InfoWriter::SecsToHMSSzzztring(const std::chrono::duration<double> totalseconds) const
-{
-	uint32_t just_seconds = trunc(totalseconds.count());
-	uint32_t hr = (uint32_t)trunc(just_seconds / 60.0 / 60.0);
-	uint32_t min = (uint32_t)trunc(just_seconds / 60.0) - (hr * 60);
-	uint32_t sec = just_seconds % 60;
-	uint32_t zzz = (uint32_t)trunc((totalseconds.count() - just_seconds) * 1000.0);
+	uint32_t zzz = totalmilliseconds % 1000;
 
 	std::string format = Settings.GetFormat();
 	std::string replacement = "\t";
@@ -67,15 +51,15 @@ std::string InfoWriter::SecsToHMSSzzztring(const std::chrono::duration<double> t
 	return buffer;
 }
 
-int64_t InfoWriter::getPausedTime(const int64_t currentTime) const
+uint64_t InfoWriter::getPausedTimeNs(const uint64_t currentTimeNs) const
 {
-	auto PausedTmpTime = PausedTotalTime;
+	auto PausedTmpTimeNs = PausedTotalTimeNs;
 
 	if (Paused) {
-		PausedTmpTime = PausedTotalTime + (currentTime - PausedStartTime);
+		PausedTmpTimeNs = PausedTotalTimeNs + (currentTimeNs - PausedStartTimeNs);
 	}
 
-	return PausedTmpTime;
+	return PausedTmpTimeNs;
 }
 
 void InfoWriter::WriteInfo(const std::string AExtraInfo) const
@@ -86,19 +70,21 @@ void InfoWriter::WriteInfo(const std::string AExtraInfo) const
 	char crlf[] = GFNATIVENEXTLINE;
 
 	std::string Info;
-	auto currentTime = Groundfloor::GetTimestamp();
-	auto tmpTime = SecsToHMSString(0);
+	auto currentTimeNs = os_gettime_ns();
+	auto tmpTime = MillisToHMSString(0);
 
-	auto PausedTmpTime = getPausedTime(currentTime);
+	auto PausedTmpTimeNs = getPausedTimeNs(currentTimeNs);
 
 	if (RecordStarted) {
-		tmpTime = SecsToHMSString((currentTime - StartRecordTime) - PausedTmpTime);
+		int64_t elapsedMs = (int64_t)((currentTimeNs - StartRecordTimeNs - PausedTmpTimeNs) / 1000000);
+		tmpTime = MillisToHMSString(elapsedMs);
 	}
 
 	std::string record_info = tmpTime;
-	tmpTime = SecsToHMSString(0);
+	tmpTime = MillisToHMSString(0);
 	if (StreamStarted) {
-		tmpTime = SecsToHMSString(currentTime - StartStreamTime);
+		int64_t elapsedMs = (int64_t)((currentTimeNs - StartStreamTimeNs) / 1000000);
+		tmpTime = MillisToHMSString(elapsedMs);
 	}
 	auto stream_info = tmpTime;
 
@@ -133,19 +119,21 @@ void InfoWriter::WriteInfo(const InfoHotkey AHotkey) const
 	if (output == nullptr)
 		return;
 
-	auto Now = Groundfloor::GetTimestamp();
+	auto NowNs = os_gettime_ns();
 	auto hotkey_text = Settings.GetHotkeyText(AHotkey);
 
 	if (lastInfoMediaType == imtStream) {
-		if (StartStreamTime == 0)
+		if (StartStreamTimeNs == 0)
 			return;
 
-		output->HotkeyMarker(Now - StartStreamTime, hotkey_text);
+		int64_t elapsedMs = (int64_t)((NowNs - StartStreamTimeNs) / 1000000);
+		output->HotkeyMarker(elapsedMs, hotkey_text);
 	} else {
-		if (StartRecordTime == 0)
+		if (StartRecordTimeNs == 0)
 			return;
 
-		output->HotkeyMarker(Now - StartRecordTime - getPausedTime(Now), hotkey_text);
+		int64_t elapsedMs = (int64_t)((NowNs - StartRecordTimeNs - getPausedTimeNs(NowNs)) / 1000000);
+		output->HotkeyMarker(elapsedMs, hotkey_text);
 	}
 
 	this->WriteInfo("");
@@ -156,23 +144,25 @@ void InfoWriter::WriteSceneChange(const std::string scenename) const
 	if (output == nullptr)
 		return;
 
-	auto Now = Groundfloor::GetTimestamp();
+	auto NowNs = os_gettime_ns();
 
 	if (lastInfoMediaType == imtStream) {
-		if (StartStreamTime == 0)
+		if (StartStreamTimeNs == 0)
 			return;
+		int64_t elapsedMs = (int64_t)((NowNs - StartStreamTimeNs) / 1000000);
 		if (scenename == "") {
-			output->ScenechangeMarker(Now - StartStreamTime, "UNKNO");
+			output->ScenechangeMarker(elapsedMs, "UNKNO");
 		} else {
-			output->ScenechangeMarker(Now - StartStreamTime, scenename);
+			output->ScenechangeMarker(elapsedMs, scenename);
 		}
 	} else {
-		if (StartRecordTime == 0)
+		if (StartRecordTimeNs == 0)
 			return;
+		int64_t elapsedMs = (int64_t)((NowNs - StartRecordTimeNs - getPausedTimeNs(NowNs)) / 1000000);
 		if (scenename == "") {
-			output->ScenechangeMarker(Now - StartRecordTime - getPausedTime(Now), "UNKNO");
+			output->ScenechangeMarker(elapsedMs, "UNKNO");
 		} else {
-			output->ScenechangeMarker(Now - StartRecordTime - getPausedTime(Now), scenename);
+			output->ScenechangeMarker(elapsedMs, scenename);
 		}
 	}
 
@@ -221,7 +211,6 @@ bool InfoWriter::RenameCurrentFile(const std::string &newFilename)
 void InfoWriter::MarkStart(InfoMediaType AType)
 {
 	StartTime = Groundfloor::GetTimestamp();
-	StartTimePoint = std::chrono::steady_clock::now();
 
 	InitCurrentFilename();
 
@@ -244,8 +233,8 @@ void InfoWriter::MarkStart(InfoMediaType AType)
 
 	switch (AType) {
 	case imtStream:
-		StartStreamTime = StartTime;
-		StartStreamTimePoint = StartTimePoint;
+		StartStreamTimeNs = os_gettime_ns();
+		StreamStarted = true;
 		if (this->Settings.GetShouldLogStreaming()) {
 			MarkStr->prepend_ansi("EVENT:START STREAM @ ");
 		}
@@ -256,8 +245,7 @@ void InfoWriter::MarkStart(InfoMediaType AType)
 		break;
 	case imtRecording:
 		MarkStr->prepend_ansi("EVENT:START RECORDING @ ");
-		StartRecordTime = StartTime;
-		StartRecordTimePoint = StartTimePoint;
+		StartRecordTimeNs = os_gettime_ns();
 		RecordStarted = true;
 		Paused = false;
 		output->TextMarker(MarkStr->getValue());
@@ -278,28 +266,29 @@ void InfoWriter::MarkStop(InfoMediaType AType)
 	if (output == nullptr)
 		return;
 
+	auto NowNs = os_gettime_ns();
 	auto Now = Groundfloor::GetTimestamp();
 	auto MarkStr = std::unique_ptr<Groundfloor::String>{Groundfloor::TimestampToStr(c_TimestampNotation, Now)};
 
 	switch (AType) {
 	case imtStream:
-		if (StartStreamTime == 0)
+		if (StartStreamTimeNs == 0)
 			return;
-		output->Stop(Now - StartStreamTime);
+		output->Stop((int64_t)((NowNs - StartStreamTimeNs) / 1000000));
 		MarkStr->prepend_ansi("EVENT:STOP STREAM @ ");
 		MarkStr->append(" Stream Time Marker Reset to 0");
 		StreamStarted = false;
-		StartStreamTime = 0;
+		StartStreamTimeNs = 0;
 		break;
 	case imtUnknown:
 	case imtRecording:
-		if (StartRecordTime == 0)
+		if (StartRecordTimeNs == 0)
 			return;
-		output->Stop(Now - StartRecordTime - getPausedTime(Now));
+		output->Stop((int64_t)((NowNs - StartRecordTimeNs - getPausedTimeNs(NowNs)) / 1000000));
 		MarkStr->prepend_ansi("EVENT:STOP RECORDING @ ");
 		MarkStr->append(" Record Time Marker Reset to 0");
-		StartRecordTime = 0; //reset times
-		PausedTotalTime = 0;
+		StartRecordTimeNs = 0;
+		PausedTotalTimeNs = 0;
 		Paused = false;
 		RecordStarted = false;
 		break;
@@ -328,9 +317,10 @@ void InfoWriter::MarkPauseStart([[maybe_unused]] const InfoMediaType AType)
 		return;
 
 	Paused = true;
-	PausedStartTime = Groundfloor::GetTimestamp();
+	PausedStartTimeNs = os_gettime_ns();
 
-	output->PausedMarker(PausedStartTime - StartTime);
+	int64_t elapsedMs = (int64_t)((PausedStartTimeNs - StartRecordTimeNs - PausedTotalTimeNs) / 1000000);
+	output->PausedMarker(elapsedMs);
 	this->WriteInfo("");
 }
 
@@ -340,10 +330,13 @@ void InfoWriter::MarkPauseResume([[maybe_unused]] const InfoMediaType AType)
 		return;
 
 	Paused = false;
-	auto CurrentTime = Groundfloor::GetTimestamp();
-	PausedTotalTime += (CurrentTime - PausedStartTime);
+	auto CurrentTimeNs = os_gettime_ns();
+	auto pauseDurationNs = CurrentTimeNs - PausedStartTimeNs;
+	PausedTotalTimeNs += pauseDurationNs;
 
-	output->ResumedMarker(CurrentTime - StartTime, CurrentTime - PausedStartTime);
+	int64_t elapsedMs = (int64_t)((CurrentTimeNs - StartRecordTimeNs - PausedTotalTimeNs) / 1000000);
+	int64_t pauseDurationMs = (int64_t)(pauseDurationNs / 1000000);
+	output->ResumedMarker(elapsedMs, pauseDurationMs);
 	this->WriteInfo("");
 }
 

--- a/InfoWriter.h
+++ b/InfoWriter.h
@@ -5,7 +5,6 @@
 #include <Groundfloor/Molecules/String.h>
 #include "OutputFormat.h"
 #include <memory>
-#include <chrono>
 #include <filesystem>
 
 enum InfoMediaType {
@@ -20,15 +19,11 @@ typedef int8_t InfoHotkey;
 class InfoWriter {
 private:
 	int64_t StartTime;
-	int64_t StartRecordTime;
-	int64_t StartStreamTime;
-	int64_t PausedTotalTime;
-	int64_t PausedStartTime;
 
-	std::chrono::time_point<std::chrono::steady_clock> StartTimePoint;
-	std::chrono::time_point<std::chrono::steady_clock> StartStreamTimePoint;
-	std::chrono::time_point<std::chrono::steady_clock> StartRecordTimePoint;
-	std::chrono::time_point<std::chrono::steady_clock> StartPausedTimePoint;
+	uint64_t StartRecordTimeNs;
+	uint64_t StartStreamTimeNs;
+	uint64_t PausedTotalTimeNs;
+	uint64_t PausedStartTimeNs;
 
 	InfoMediaType lastInfoMediaType;
 
@@ -41,11 +36,10 @@ private:
 
 	std::unique_ptr<IOutputFormat> output;
 
-	int64_t getPausedTime(const int64_t currentTime) const;
+	uint64_t getPausedTimeNs(const uint64_t currentTimeNs) const;
 	void InitCurrentFilename();
 	bool RenameCurrentFile(const std::string &newFilename);
-	std::string SecsToHMSString(const int64_t totalseconds) const;
-	std::string SecsToHMSSzzztring(const std::chrono::duration<double> totalseconds) const;
+	std::string MillisToHMSString(const int64_t totalmilliseconds) const;
 
 public:
 	InfoWriter();

--- a/InfoWriter.h
+++ b/InfoWriter.h
@@ -6,6 +6,7 @@
 #include "OutputFormat.h"
 #include <memory>
 #include <chrono>
+#include <filesystem>
 
 enum InfoMediaType {
 	imtUnknown = 0,
@@ -42,6 +43,7 @@ private:
 
 	int64_t getPausedTime(const int64_t currentTime) const;
 	void InitCurrentFilename();
+	bool RenameCurrentFile(const std::string &newFilename);
 	std::string SecsToHMSString(const int64_t totalseconds) const;
 	std::string SecsToHMSSzzztring(const std::chrono::duration<double> totalseconds) const;
 

--- a/InfoWriter.h
+++ b/InfoWriter.h
@@ -5,6 +5,7 @@
 #include <Groundfloor/Molecules/String.h>
 #include "OutputFormat.h"
 #include <memory>
+#include <chrono>
 
 enum InfoMediaType {
 	imtUnknown = 0,
@@ -23,6 +24,11 @@ private:
 	int64_t PausedTotalTime;
 	int64_t PausedStartTime;
 
+	std::chrono::time_point<std::chrono::steady_clock> StartTimePoint;
+	std::chrono::time_point<std::chrono::steady_clock> StartStreamTimePoint;
+	std::chrono::time_point<std::chrono::steady_clock> StartRecordTimePoint;
+	std::chrono::time_point<std::chrono::steady_clock> StartPausedTimePoint;
+
 	InfoMediaType lastInfoMediaType;
 
 	InfoWriterSettings Settings;
@@ -37,6 +43,7 @@ private:
 	int64_t getPausedTime(const int64_t currentTime) const;
 	void InitCurrentFilename();
 	std::string SecsToHMSString(const int64_t totalseconds) const;
+	std::string SecsToHMSSzzztring(const std::chrono::duration<double> totalseconds) const;
 
 public:
 	InfoWriter();

--- a/InfoWriterObsUtils.cpp
+++ b/InfoWriterObsUtils.cpp
@@ -23,3 +23,21 @@ std::optional<std::string> get_filename_from_recording_path(const InfoWriterSett
 	CurrentFilename.replace(videoextensionstart, CurrentFilename.length(), extension);
 	return CurrentFilename;
 }
+
+std::optional<std::string> get_filename_from_last_recording(const InfoWriterSettings &Settings)
+{
+	char *path = obs_frontend_get_last_recording();
+	if (!path)
+		return std::nullopt;
+
+	std::string filename = path;
+	bfree(path);
+
+	if (filename.empty())
+		return std::nullopt;
+
+	size_t videoextensionstart = filename.find_last_of('.') + 1;
+	auto extension = Settings.GetAutomaticOutputExtension();
+	filename.replace(videoextensionstart, filename.length(), extension);
+	return filename;
+}

--- a/InfoWriterObsUtils.h
+++ b/InfoWriterObsUtils.h
@@ -5,3 +5,4 @@
 #include "InfoWriterSettings.h"
 
 std::optional<std::string> get_filename_from_recording_path(const InfoWriterSettings &Settings);
+std::optional<std::string> get_filename_from_last_recording(const InfoWriterSettings &Settings);

--- a/OBSStudioInfoWriter.cpp
+++ b/OBSStudioInfoWriter.cpp
@@ -38,8 +38,8 @@ const char *setting_shouldloghotkeyspecifics = "loghotkeyspecifics";
 const char *setting_file_preview = "file_preview";
 const char *setting_format_preview = "format_preview";
 
-bool obstudio_infowriter_file_property_modified(obs_properties_t *props,
-						[[maybe_unused]] obs_property_t *property, obs_data_t *settings)
+bool obstudio_infowriter_file_property_modified(obs_properties_t *props, [[maybe_unused]] obs_property_t *property,
+						obs_data_t *settings)
 {
 	obs_property_t *preview_prop = obs_properties_get(props, setting_file_preview);
 	const char *file = obs_data_get_string(settings, setting_file);
@@ -72,8 +72,8 @@ bool obstudio_infowriter_file_property_modified(obs_properties_t *props,
 	return true;
 }
 
-bool obstudio_infowriter_format_property_modified(obs_properties_t *props,
-					       [[maybe_unused]] obs_property_t *property, obs_data_t *settings)
+bool obstudio_infowriter_format_property_modified(obs_properties_t *props, [[maybe_unused]] obs_property_t *property,
+						  obs_data_t *settings)
 {
 	obs_property_t *preview_prop = obs_properties_get(props, setting_format_preview);
 	const char *format = obs_data_get_string(settings, setting_format);
@@ -84,8 +84,9 @@ bool obstudio_infowriter_format_property_modified(obs_properties_t *props,
 	}
 
 	if (HasUnsafeFormatSpecifiers(format)) {
-		obs_data_set_string(settings, setting_format_preview,
-				    "Format contains unsafe specifiers. Only integer formats (%d, %02d, etc.) are supported.");
+		obs_data_set_string(
+			settings, setting_format_preview,
+			"Format contains unsafe specifiers. Only integer formats (%d, %02d, etc.) are supported.");
 		obs_property_text_set_info_type(preview_prop, OBS_TEXT_INFO_ERROR);
 		obs_property_set_visible(preview_prop, true);
 		return true;
@@ -93,8 +94,9 @@ bool obstudio_infowriter_format_property_modified(obs_properties_t *props,
 
 	int count = CountFormatSpecifiers(format);
 	if (count > 4) {
-		obs_data_set_string(settings, setting_format_preview,
-				    "Too many format specifiers. At most 4 are supported: hours, minutes, seconds, milliseconds.");
+		obs_data_set_string(
+			settings, setting_format_preview,
+			"Too many format specifiers. At most 4 are supported: hours, minutes, seconds, milliseconds.");
 		obs_property_text_set_info_type(preview_prop, OBS_TEXT_INFO_ERROR);
 		obs_property_set_visible(preview_prop, true);
 		return true;
@@ -375,8 +377,7 @@ obs_properties_t *obstudio_infowriter_properties(void *unused)
 	auto prop_format = obs_properties_add_text(props, setting_format, obs_module_text("Format"), OBS_TEXT_DEFAULT);
 	obs_property_set_modified_callback(prop_format, obstudio_infowriter_format_property_modified);
 
-	auto prop_format_preview =
-		obs_properties_add_text(props, setting_format_preview, "", OBS_TEXT_INFO);
+	auto prop_format_preview = obs_properties_add_text(props, setting_format_preview, "", OBS_TEXT_INFO);
 	obs_property_text_set_info_word_wrap(prop_format_preview, true);
 	obs_property_set_visible(prop_format_preview, false);
 
@@ -389,8 +390,7 @@ obs_properties_t *obstudio_infowriter_properties(void *unused)
 						 logfile_filter, NULL);
 	obs_property_set_modified_callback(prop_file, obstudio_infowriter_file_property_modified);
 
-	auto prop_file_preview =
-		obs_properties_add_text(props, setting_file_preview, "", OBS_TEXT_INFO);
+	auto prop_file_preview = obs_properties_add_text(props, setting_file_preview, "", OBS_TEXT_INFO);
 	obs_property_text_set_info_word_wrap(prop_file_preview, true);
 	obs_property_set_visible(prop_file_preview, false);
 

--- a/OBSStudioInfoWriter.cpp
+++ b/OBSStudioInfoWriter.cpp
@@ -6,7 +6,9 @@
 #include <Groundfloor/Materials/FileWriter.h>
 #include <Groundfloor/Materials/Functions.h>
 #include <Groundfloor/Atoms/Defines.h>
+#include <string>
 #include "InfoWriter.h"
+#include "FormatUtils.h"
 
 const char *infowriter_idname = "Info Writer";
 const char *logfile_filter = "All formats (*.*)";
@@ -33,6 +35,79 @@ const char *setting_shouldlogscenechanges = "logscenechanges";
 const char *setting_shouldlogstreaming = "logstreaming";
 const char *setting_shouldlogabsolutetime = "logabsolutetime";
 const char *setting_shouldloghotkeyspecifics = "loghotkeyspecifics";
+const char *setting_file_preview = "file_preview";
+const char *setting_format_preview = "format_preview";
+
+bool obstudio_infowriter_file_property_modified(obs_properties_t *props,
+						[[maybe_unused]] obs_property_t *property, obs_data_t *settings)
+{
+	obs_property_t *preview_prop = obs_properties_get(props, setting_file_preview);
+	const char *file = obs_data_get_string(settings, setting_file);
+
+	if (!file || strlen(file) == 0) {
+		obs_property_set_visible(preview_prop, false);
+		return true;
+	}
+
+	// If filename has no strftime specifiers, no preview needed
+	if (std::string(file).find('%') == std::string::npos) {
+		obs_property_set_visible(preview_prop, false);
+		return true;
+	}
+
+	try {
+		auto *formatted = Groundfloor::TimestampToStr(file, Groundfloor::GetTimestamp());
+		std::string preview = "Preview: " + std::string(formatted->getValue());
+		delete formatted;
+
+		obs_data_set_string(settings, setting_file_preview, preview.c_str());
+		obs_property_text_set_info_type(preview_prop, OBS_TEXT_INFO_NORMAL);
+		obs_property_set_visible(preview_prop, true);
+	} catch (const std::runtime_error &e) {
+		obs_data_set_string(settings, setting_file_preview, e.what());
+		obs_property_text_set_info_type(preview_prop, OBS_TEXT_INFO_ERROR);
+		obs_property_set_visible(preview_prop, true);
+	}
+
+	return true;
+}
+
+bool obstudio_infowriter_format_property_modified(obs_properties_t *props,
+					       [[maybe_unused]] obs_property_t *property, obs_data_t *settings)
+{
+	obs_property_t *preview_prop = obs_properties_get(props, setting_format_preview);
+	const char *format = obs_data_get_string(settings, setting_format);
+
+	if (!format || strlen(format) == 0) {
+		obs_property_set_visible(preview_prop, false);
+		return true;
+	}
+
+	if (HasUnsafeFormatSpecifiers(format)) {
+		obs_data_set_string(settings, setting_format_preview,
+				    "Format contains unsafe specifiers. Only integer formats (%d, %02d, etc.) are supported.");
+		obs_property_text_set_info_type(preview_prop, OBS_TEXT_INFO_ERROR);
+		obs_property_set_visible(preview_prop, true);
+		return true;
+	}
+
+	int count = CountFormatSpecifiers(format);
+	if (count > 4) {
+		obs_data_set_string(settings, setting_format_preview,
+				    "Too many format specifiers. At most 4 are supported: hours, minutes, seconds, milliseconds.");
+		obs_property_text_set_info_type(preview_prop, OBS_TEXT_INFO_ERROR);
+		obs_property_set_visible(preview_prop, true);
+		return true;
+	}
+
+	// 1h 23m 45s 678ms = 5025678ms
+	const int64_t example_ms = 1 * 3600000 + 23 * 60000 + 45 * 1000 + 678;
+	std::string preview = "Preview: " + FormatMillisToHMS(format, example_ms);
+	obs_data_set_string(settings, setting_format_preview, preview.c_str());
+	obs_property_text_set_info_type(preview_prop, OBS_TEXT_INFO_NORMAL);
+	obs_property_set_visible(preview_prop, true);
+	return true;
+}
 
 bool obstudio_infowriter_syncnameandpathwithvideo_property_modified(obs_properties_t *props,
 								    [[maybe_unused]] obs_property_t *property,
@@ -297,14 +372,27 @@ obs_properties_t *obstudio_infowriter_properties(void *unused)
 	obs_property_list_add_string(list, "EDL", "edl");
 	obs_property_list_add_string(list, "SRT", "srt");
 
-	obs_properties_add_text(props, setting_format, obs_module_text("Format"), OBS_TEXT_DEFAULT);
+	auto prop_format = obs_properties_add_text(props, setting_format, obs_module_text("Format"), OBS_TEXT_DEFAULT);
+	obs_property_set_modified_callback(prop_format, obstudio_infowriter_format_property_modified);
+
+	auto prop_format_preview =
+		obs_properties_add_text(props, setting_format_preview, "", OBS_TEXT_INFO);
+	obs_property_text_set_info_word_wrap(prop_format_preview, true);
+	obs_property_set_visible(prop_format_preview, false);
+
 	obs_property *prop_syncnameandpathwithvideo =
 		obs_properties_add_bool(props, setting_syncnameandpathwithvideo, "Sync with video file name and path");
 	obs_property_set_modified_callback(prop_syncnameandpathwithvideo,
 					   obstudio_infowriter_syncnameandpathwithvideo_property_modified);
 	obs_properties_add_text(props, setting_automaticoutputextension, "Automatic file extension", OBS_TEXT_DEFAULT);
-	obs_properties_add_path(props, setting_file, obs_module_text("Logfile"), OBS_PATH_FILE_SAVE, logfile_filter,
-				NULL);
+	auto prop_file = obs_properties_add_path(props, setting_file, obs_module_text("Logfile"), OBS_PATH_FILE_SAVE,
+						 logfile_filter, NULL);
+	obs_property_set_modified_callback(prop_file, obstudio_infowriter_file_property_modified);
+
+	auto prop_file_preview =
+		obs_properties_add_text(props, setting_file_preview, "", OBS_TEXT_INFO);
+	obs_property_text_set_info_word_wrap(prop_file_preview, true);
+	obs_property_set_visible(prop_file_preview, false);
 
 	obs_properties_add_text(props, setting_hotkey1text, obs_module_text("Hotkey 1 text"), OBS_TEXT_DEFAULT);
 	obs_properties_add_text(props, setting_hotkey2text, obs_module_text("Hotkey 2 text"), OBS_TEXT_DEFAULT);

--- a/OutputFormat.h
+++ b/OutputFormat.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 class IOutputFormat {
@@ -7,15 +8,15 @@ public:
 	virtual ~IOutputFormat() = default;
 
 	virtual void Start() = 0;
-	virtual void Stop(const int64_t timestamp) = 0;
+	virtual void Stop(const int64_t milliseconds) = 0;
 
-	virtual void HotkeyMarker(const int64_t timestamp,
+	virtual void HotkeyMarker(const int64_t milliseconds,
 				  const std::string text) = 0;
-	virtual void ScenechangeMarker(const int64_t timestamp,
+	virtual void ScenechangeMarker(const int64_t milliseconds,
 				       const std::string scenename) = 0;
-	virtual void PausedMarker(const int64_t timestamp) = 0;
-	virtual void ResumedMarker(const int64_t timestamp,
-				   const int64_t pauselength) = 0;
+	virtual void PausedMarker(const int64_t milliseconds) = 0;
+	virtual void ResumedMarker(const int64_t milliseconds,
+				   const int64_t pauselength_ms) = 0;
 
 	virtual void TextMarker(const std::string text) = 0;
 };

--- a/OutputFormat.h
+++ b/OutputFormat.h
@@ -10,13 +10,10 @@ public:
 	virtual void Start() = 0;
 	virtual void Stop(const int64_t milliseconds) = 0;
 
-	virtual void HotkeyMarker(const int64_t milliseconds,
-				  const std::string text) = 0;
-	virtual void ScenechangeMarker(const int64_t milliseconds,
-				       const std::string scenename) = 0;
+	virtual void HotkeyMarker(const int64_t milliseconds, const std::string text) = 0;
+	virtual void ScenechangeMarker(const int64_t milliseconds, const std::string scenename) = 0;
 	virtual void PausedMarker(const int64_t milliseconds) = 0;
-	virtual void ResumedMarker(const int64_t milliseconds,
-				   const int64_t pauselength_ms) = 0;
+	virtual void ResumedMarker(const int64_t milliseconds, const int64_t pauselength_ms) = 0;
 
 	virtual void TextMarker(const std::string text) = 0;
 };

--- a/OutputFormat/OutputFormat.CSV.cpp
+++ b/OutputFormat/OutputFormat.CSV.cpp
@@ -10,11 +10,13 @@ OutputFormatCSV::OutputFormatCSV(const InfoWriterSettings &settings, const std::
 {
 }
 
-std::string OutputFormatCSV::SecsToHMSString(const int64_t totalseconds) const
+std::string OutputFormatCSV::MillisToHMSString(const int64_t totalmilliseconds) const
 {
+	int64_t totalseconds = totalmilliseconds / 1000;
 	uint32_t hr = (uint32_t)trunc(totalseconds / 60.0 / 60.0);
 	uint32_t min = (uint32_t)trunc(totalseconds / 60.0) - (hr * 60);
 	uint32_t sec = totalseconds % 60;
+	uint32_t zzz = totalmilliseconds % 1000;
 
 	std::string format = settings.GetFormat();
 	std::string replacement = "\t";
@@ -23,7 +25,7 @@ std::string OutputFormatCSV::SecsToHMSString(const int64_t totalseconds) const
 	format += "\0\0\0\0";
 
 	char buffer[1024];
-	sprintf(&buffer[0], format.c_str(), hr, min, sec);
+	sprintf(&buffer[0], format.c_str(), hr, min, sec, zzz);
 
 	return buffer;
 }
@@ -47,33 +49,33 @@ void OutputFormatCSV::WriteGFStringToFile(const std::string filename, const std:
 
 void OutputFormatCSV::Start() {}
 
-void OutputFormatCSV::Stop([[maybe_unused]] const int64_t timestamp) {}
+void OutputFormatCSV::Stop([[maybe_unused]] const int64_t milliseconds) {}
 
-void OutputFormatCSV::WriteCSVLine(const int64_t timestamp, const std::string text) const
+void OutputFormatCSV::WriteCSVLine(const int64_t milliseconds, const std::string text) const
 {
 	char crlf[] = GFNATIVENEXTLINE;
 
-	auto formattedTime = SecsToHMSString(timestamp);
+	auto formattedTime = MillisToHMSString(milliseconds);
 
 	std::string line = formattedTime + "," + text + crlf;
 
 	WriteGFStringToFile(currentFilename, line);
 }
 
-void OutputFormatCSV::HotkeyMarker(const int64_t timestamp, const std::string text)
+void OutputFormatCSV::HotkeyMarker(const int64_t milliseconds, const std::string text)
 {
-	WriteCSVLine(timestamp, text);
+	WriteCSVLine(milliseconds, text);
 }
 
-void OutputFormatCSV::ScenechangeMarker(const int64_t timestamp, const std::string scenename)
+void OutputFormatCSV::ScenechangeMarker(const int64_t milliseconds, const std::string scenename)
 {
-	WriteCSVLine(timestamp, scenename);
+	WriteCSVLine(milliseconds, scenename);
 }
 
-void OutputFormatCSV::PausedMarker([[maybe_unused]] const int64_t timestamp) {}
+void OutputFormatCSV::PausedMarker([[maybe_unused]] const int64_t milliseconds) {}
 
-void OutputFormatCSV::ResumedMarker([[maybe_unused]] const int64_t timestamp,
-				    [[maybe_unused]] const int64_t pauselength)
+void OutputFormatCSV::ResumedMarker([[maybe_unused]] const int64_t milliseconds,
+				    [[maybe_unused]] const int64_t pauselength_ms)
 {
 }
 

--- a/OutputFormat/OutputFormat.CSV.cpp
+++ b/OutputFormat/OutputFormat.CSV.cpp
@@ -1,7 +1,6 @@
 #include "OutputFormat.CSV.h"
+#include "../FormatUtils.h"
 #include <Groundfloor/Materials/FileWriter.h>
-#include <regex>
-#include <cmath>
 
 OutputFormatCSV::OutputFormatCSV(const InfoWriterSettings &settings, const std::string filename)
 	: IOutputFormat(),
@@ -12,22 +11,7 @@ OutputFormatCSV::OutputFormatCSV(const InfoWriterSettings &settings, const std::
 
 std::string OutputFormatCSV::MillisToHMSString(const int64_t totalmilliseconds) const
 {
-	int64_t totalseconds = totalmilliseconds / 1000;
-	uint32_t hr = (uint32_t)trunc(totalseconds / 60.0 / 60.0);
-	uint32_t min = (uint32_t)trunc(totalseconds / 60.0) - (hr * 60);
-	uint32_t sec = totalseconds % 60;
-	uint32_t zzz = totalmilliseconds % 1000;
-
-	std::string format = settings.GetFormat();
-	std::string replacement = "\t";
-	std::regex tabregex("(\\\\t)");
-	format = std::regex_replace(format, tabregex, replacement);
-	format += "\0\0\0\0";
-
-	char buffer[1024];
-	sprintf(&buffer[0], format.c_str(), hr, min, sec, zzz);
-
-	return buffer;
+	return FormatMillisToHMS(settings.GetFormat(), totalmilliseconds);
 }
 
 void OutputFormatCSV::WriteGFStringToFile(const std::string filename, const std::string text) const

--- a/OutputFormat/OutputFormat.CSV.h
+++ b/OutputFormat/OutputFormat.CSV.h
@@ -8,18 +8,18 @@ class OutputFormatCSV final : public IOutputFormat {
 private:
 	const InfoWriterSettings &settings;
 	std::string currentFilename;
-	std::string SecsToHMSString(const int64_t totalseconds) const;
+	std::string MillisToHMSString(const int64_t totalmilliseconds) const;
 	void WriteGFStringToFile(const std::string filename, const std::string text) const;
-	void WriteCSVLine(const int64_t timestamp, const std::string text) const;
+	void WriteCSVLine(const int64_t milliseconds, const std::string text) const;
 
 public:
 	OutputFormatCSV(const InfoWriterSettings &settings, const std::string filename);
 
 	void Start() override;
-	void Stop(const int64_t timestamp) override;
-	void HotkeyMarker(const int64_t timestamp, const std::string text) override;
-	void ScenechangeMarker(const int64_t timestamp, const std::string scenename) override;
-	void PausedMarker(const int64_t timestamp) override;
-	void ResumedMarker(const int64_t timestamp, const int64_t pauselength) override;
+	void Stop(const int64_t milliseconds) override;
+	void HotkeyMarker(const int64_t milliseconds, const std::string text) override;
+	void ScenechangeMarker(const int64_t milliseconds, const std::string scenename) override;
+	void PausedMarker(const int64_t milliseconds) override;
+	void ResumedMarker(const int64_t milliseconds, const int64_t pauselength_ms) override;
 	void TextMarker(const std::string text) override;
 };

--- a/OutputFormat/OutputFormat.Default.cpp
+++ b/OutputFormat/OutputFormat.Default.cpp
@@ -15,11 +15,13 @@ OutputFormatDefault::OutputFormatDefault(const InfoWriterSettings &settings, con
 {
 }
 
-std::string OutputFormatDefault::SecsToHMSString(const int64_t totalseconds) const
+std::string OutputFormatDefault::MillisToHMSString(const int64_t totalmilliseconds) const
 {
+	int64_t totalseconds = totalmilliseconds / 1000;
 	uint32_t hr = (uint32_t)trunc(totalseconds / 60.0 / 60.0);
 	uint32_t min = (uint32_t)trunc(totalseconds / 60.0) - (hr * 60);
 	uint32_t sec = totalseconds % 60;
+	uint32_t zzz = totalmilliseconds % 1000;
 
 	std::string format = settings.GetFormat();
 	std::string replacement = "\t";
@@ -28,16 +30,9 @@ std::string OutputFormatDefault::SecsToHMSString(const int64_t totalseconds) con
 	format += "\0\0\0\0";
 
 	char buffer[1024];
-	sprintf(&buffer[0], format.c_str(), hr, min, sec);
+	sprintf(&buffer[0], format.c_str(), hr, min, sec, zzz);
 
 	return buffer;
-}
-
-std::string OutputFormatDefault::MilliToHMSString(const int64_t time) const
-{
-	uint32_t totalseconds = (uint32_t)trunc(time / 1000.0);
-
-	return SecsToHMSString(totalseconds);
 }
 
 void OutputFormatDefault::WriteToFile(const std::string Data) const
@@ -81,14 +76,14 @@ void OutputFormatDefault::Start()
 	startTime = Groundfloor::GetTimestamp();
 }
 
-void OutputFormatDefault::Stop([[maybe_unused]] const int64_t timestamp) {}
+void OutputFormatDefault::Stop([[maybe_unused]] const int64_t milliseconds) {}
 
-void OutputFormatDefault::HotkeyMarker(const int64_t timestamp, const std::string text)
+void OutputFormatDefault::HotkeyMarker(const int64_t milliseconds, const std::string text)
 {
 	if (this->settings.GetShouldLogHotkeySpecifics()) {
 		if (this->settings.GetShouldLogAbsoluteTime()) {
-			auto MarkStr =
-				Groundfloor::TimestampToStr(c_OutputDefaultTimestampNotation, startTime + timestamp);
+			auto MarkStr = Groundfloor::TimestampToStr(c_OutputDefaultTimestampNotation,
+								   startTime + (milliseconds / 1000));
 			auto hotkey_text = "HOTKEY:" + text + " @ " + MarkStr->getValue();
 			WriteToFile(hotkey_text);
 			delete MarkStr;
@@ -99,9 +94,10 @@ void OutputFormatDefault::HotkeyMarker(const int64_t timestamp, const std::strin
 	}
 }
 
-void OutputFormatDefault::ScenechangeMarker(const int64_t timestamp, const std::string scenename)
+void OutputFormatDefault::ScenechangeMarker(const int64_t milliseconds, const std::string scenename)
 {
-	auto MarkStr = Groundfloor::TimestampToStr(c_OutputDefaultTimestampNotation, startTime + timestamp);
+	auto MarkStr =
+		Groundfloor::TimestampToStr(c_OutputDefaultTimestampNotation, startTime + (milliseconds / 1000));
 
 	if (scenename == "") {
 		WriteToFile("EVENT:SCENE CHANGED @ " + std::string(MarkStr->getValue()));
@@ -112,22 +108,24 @@ void OutputFormatDefault::ScenechangeMarker(const int64_t timestamp, const std::
 	delete MarkStr;
 }
 
-void OutputFormatDefault::PausedMarker(const int64_t timestamp)
+void OutputFormatDefault::PausedMarker(const int64_t milliseconds)
 {
-	auto MarkStr = Groundfloor::TimestampToStr(c_OutputDefaultTimestampNotation, startTime + timestamp);
+	auto MarkStr =
+		Groundfloor::TimestampToStr(c_OutputDefaultTimestampNotation, startTime + (milliseconds / 1000));
 
 	WriteToFile("EVENT:RECORDING PAUSED @ " + std::string(MarkStr->getValue()));
 
 	delete MarkStr;
 }
 
-void OutputFormatDefault::ResumedMarker(const int64_t timestamp, const int64_t pauselength)
+void OutputFormatDefault::ResumedMarker(const int64_t milliseconds, const int64_t pauselength_ms)
 {
-	auto MarkStr = Groundfloor::TimestampToStr(c_OutputDefaultTimestampNotation, startTime + timestamp);
+	auto MarkStr =
+		Groundfloor::TimestampToStr(c_OutputDefaultTimestampNotation, startTime + (milliseconds / 1000));
 
 	std::string Info;
 	Info = "EVENT:RECORDING RESUMED @ " + std::string(MarkStr->getValue()) + " (paused lasted for ";
-	Info += SecsToHMSString(pauselength);
+	Info += MillisToHMSString(pauselength_ms);
 	Info += " seconds)";
 
 	delete MarkStr;

--- a/OutputFormat/OutputFormat.Default.cpp
+++ b/OutputFormat/OutputFormat.Default.cpp
@@ -1,8 +1,7 @@
 #include "OutputFormat.Default.h"
+#include "../FormatUtils.h"
 #include <Groundfloor/Materials/Functions.h>
 #include <Groundfloor/Materials/FileWriter.h>
-#include <regex>
-#include <cmath>
 #include <cstdint>
 
 const char *c_OutputDefaultTimestampNotation = "%Y-%m-%d %H:%M:%S";
@@ -17,22 +16,7 @@ OutputFormatDefault::OutputFormatDefault(const InfoWriterSettings &settings, con
 
 std::string OutputFormatDefault::MillisToHMSString(const int64_t totalmilliseconds) const
 {
-	int64_t totalseconds = totalmilliseconds / 1000;
-	uint32_t hr = (uint32_t)trunc(totalseconds / 60.0 / 60.0);
-	uint32_t min = (uint32_t)trunc(totalseconds / 60.0) - (hr * 60);
-	uint32_t sec = totalseconds % 60;
-	uint32_t zzz = totalmilliseconds % 1000;
-
-	std::string format = settings.GetFormat();
-	std::string replacement = "\t";
-	std::regex tabregex("(\\\\t)");
-	format = std::regex_replace(format, tabregex, replacement);
-	format += "\0\0\0\0";
-
-	char buffer[1024];
-	sprintf(&buffer[0], format.c_str(), hr, min, sec, zzz);
-
-	return buffer;
+	return FormatMillisToHMS(settings.GetFormat(), totalmilliseconds);
 }
 
 void OutputFormatDefault::WriteToFile(const std::string Data) const

--- a/OutputFormat/OutputFormat.Default.cpp
+++ b/OutputFormat/OutputFormat.Default.cpp
@@ -80,8 +80,7 @@ void OutputFormatDefault::HotkeyMarker(const int64_t milliseconds, const std::st
 
 void OutputFormatDefault::ScenechangeMarker(const int64_t milliseconds, const std::string scenename)
 {
-	auto MarkStr =
-		Groundfloor::TimestampToStr(c_OutputDefaultTimestampNotation, startTime + (milliseconds / 1000));
+	auto MarkStr = Groundfloor::TimestampToStr(c_OutputDefaultTimestampNotation, startTime + (milliseconds / 1000));
 
 	if (scenename == "") {
 		WriteToFile("EVENT:SCENE CHANGED @ " + std::string(MarkStr->getValue()));
@@ -94,8 +93,7 @@ void OutputFormatDefault::ScenechangeMarker(const int64_t milliseconds, const st
 
 void OutputFormatDefault::PausedMarker(const int64_t milliseconds)
 {
-	auto MarkStr =
-		Groundfloor::TimestampToStr(c_OutputDefaultTimestampNotation, startTime + (milliseconds / 1000));
+	auto MarkStr = Groundfloor::TimestampToStr(c_OutputDefaultTimestampNotation, startTime + (milliseconds / 1000));
 
 	WriteToFile("EVENT:RECORDING PAUSED @ " + std::string(MarkStr->getValue()));
 
@@ -104,8 +102,7 @@ void OutputFormatDefault::PausedMarker(const int64_t milliseconds)
 
 void OutputFormatDefault::ResumedMarker(const int64_t milliseconds, const int64_t pauselength_ms)
 {
-	auto MarkStr =
-		Groundfloor::TimestampToStr(c_OutputDefaultTimestampNotation, startTime + (milliseconds / 1000));
+	auto MarkStr = Groundfloor::TimestampToStr(c_OutputDefaultTimestampNotation, startTime + (milliseconds / 1000));
 
 	std::string Info;
 	Info = "EVENT:RECORDING RESUMED @ " + std::string(MarkStr->getValue()) + " (paused lasted for ";

--- a/OutputFormat/OutputFormat.Default.h
+++ b/OutputFormat/OutputFormat.Default.h
@@ -10,8 +10,7 @@ private:
 	std::string currentFilename;
 	int64_t startTime;
 
-	std::string SecsToHMSString(const int64_t totalseconds) const;
-	std::string MilliToHMSString(const int64_t time) const;
+	std::string MillisToHMSString(const int64_t totalmilliseconds) const;
 	void WriteToFile(const std::string Data) const;
 	void WriteDblLineToFile(const std::string Data) const;
 	void WriteGFStringToFile(const Groundfloor::String &SData) const;
@@ -20,12 +19,12 @@ public:
 	OutputFormatDefault(const InfoWriterSettings &settings, const std::string filename);
 
 	void Start() override;
-	void Stop(const int64_t timestamp) override;
+	void Stop(const int64_t milliseconds) override;
 
-	void HotkeyMarker(const int64_t timestamp, const std::string text) override;
-	void ScenechangeMarker(const int64_t timestamp, const std::string scenename) override;
-	void PausedMarker(const int64_t timestamp) override;
-	void ResumedMarker(const int64_t timestamp, const int64_t pauselength) override;
+	void HotkeyMarker(const int64_t milliseconds, const std::string text) override;
+	void ScenechangeMarker(const int64_t milliseconds, const std::string scenename) override;
+	void PausedMarker(const int64_t milliseconds) override;
+	void ResumedMarker(const int64_t milliseconds, const int64_t pauselength_ms) override;
 
 	void TextMarker(const std::string text) override;
 };

--- a/OutputFormat/OutputFormat.EDL.cpp
+++ b/OutputFormat/OutputFormat.EDL.cpp
@@ -30,16 +30,18 @@ void OutputFormatEDL::WriteGFStringToFile(const Groundfloor::String &SData) cons
 	Writer.close();
 }
 
-std::string OutputFormatEDL::SecsToHMSString(const int64_t totalseconds) const
+std::string OutputFormatEDL::MillisToHMSString(const int64_t totalmilliseconds) const
 {
+	int64_t totalseconds = totalmilliseconds / 1000;
 	uint32_t hr = (uint32_t)trunc(totalseconds / 60.0 / 60.0);
 	uint32_t min = (uint32_t)trunc(totalseconds / 60.0) - (hr * 60);
 	uint32_t sec = totalseconds % 60;
+	uint32_t cs = (totalmilliseconds % 1000) / 10;
 
 	const char *timeformat = "%02d:%02d:%02d:%02d";
 
 	char buffer[14];
-	sprintf(&buffer[0], timeformat, hr, min, sec, 0);
+	sprintf(&buffer[0], timeformat, hr, min, sec, cs);
 
 	return buffer;
 }
@@ -73,14 +75,14 @@ std::string FilterReelName(const std::string text)
 	return reelname;
 }
 
-void OutputFormatEDL::writeMarker(const int64_t start, const int64_t stop, const std::string text) const
+void OutputFormatEDL::writeMarker(const int64_t start_ms, const int64_t stop_ms, const std::string text) const
 {
 	char crlf[] = GFNATIVENEXTLINE;
 
 	auto markername = FilterReelName(text);
 
-	auto formattedStartTime = SecsToHMSString(start);
-	auto formattedStopTime = SecsToHMSString(stop);
+	auto formattedStartTime = MillisToHMSString(start_ms);
+	auto formattedStopTime = MillisToHMSString(stop_ms);
 
 	const char *edlformat = "%03d  %s V     C        %s %s %s %s";
 	char line[200];
@@ -100,36 +102,36 @@ void OutputFormatEDL::Start()
 	this->lastMarkerText = "START";
 }
 
-void OutputFormatEDL::Stop(const int64_t timestamp)
+void OutputFormatEDL::Stop(const int64_t milliseconds)
 {
 	// -1 second because if the length is longer than the written video, software might like this EDL even less than it already does
-	writeMarker(lastMarker, timestamp - 1, lastMarkerText);
+	writeMarker(lastMarker, milliseconds - 1000, lastMarkerText);
 }
 
-void OutputFormatEDL::HotkeyMarker(const int64_t timestamp, const std::string text)
+void OutputFormatEDL::HotkeyMarker(const int64_t milliseconds, const std::string text)
 {
-	writeMarker(lastMarker, timestamp, lastMarkerText);
+	writeMarker(lastMarker, milliseconds, lastMarkerText);
 
-	lastMarker = timestamp;
+	lastMarker = milliseconds;
 	lastMarkerText = text;
 
 	markercount++;
 }
 
-void OutputFormatEDL::ScenechangeMarker(const int64_t timestamp, const std::string scenename)
+void OutputFormatEDL::ScenechangeMarker(const int64_t milliseconds, const std::string scenename)
 {
-	writeMarker(lastMarker, timestamp, lastMarkerText);
+	writeMarker(lastMarker, milliseconds, lastMarkerText);
 
-	lastMarker = timestamp;
+	lastMarker = milliseconds;
 	lastMarkerText = scenename;
 
 	markercount++;
 }
 
-void OutputFormatEDL::PausedMarker([[maybe_unused]] const int64_t timestamp) {}
+void OutputFormatEDL::PausedMarker([[maybe_unused]] const int64_t milliseconds) {}
 
-void OutputFormatEDL::ResumedMarker([[maybe_unused]] const int64_t timestamp,
-				    [[maybe_unused]] const int64_t pauselength)
+void OutputFormatEDL::ResumedMarker([[maybe_unused]] const int64_t milliseconds,
+				    [[maybe_unused]] const int64_t pauselength_ms)
 {
 }
 

--- a/OutputFormat/OutputFormat.EDL.h
+++ b/OutputFormat/OutputFormat.EDL.h
@@ -13,18 +13,18 @@ private:
 	std::string currentFilename;
 
 	void WriteGFStringToFile(const Groundfloor::String &SData) const;
-	std::string SecsToHMSString(const int64_t totalseconds) const;
-	void writeMarker(const int64_t start, const int64_t stop, const std::string text) const;
+	std::string MillisToHMSString(const int64_t totalmilliseconds) const;
+	void writeMarker(const int64_t start_ms, const int64_t stop_ms, const std::string text) const;
 
 public:
 	OutputFormatEDL(const InfoWriterSettings &settings, const std::string filename);
 
 	void Start() override;
-	void Stop(const int64_t timestamp) override;
+	void Stop(const int64_t milliseconds) override;
 
-	void HotkeyMarker(const int64_t timestamp, const std::string text) override;
-	void ScenechangeMarker(const int64_t timestamp, const std::string scenename) override;
-	void PausedMarker(const int64_t timestamp) override;
-	void ResumedMarker(const int64_t timestamp, const int64_t pauselength) override;
+	void HotkeyMarker(const int64_t milliseconds, const std::string text) override;
+	void ScenechangeMarker(const int64_t milliseconds, const std::string scenename) override;
+	void PausedMarker(const int64_t milliseconds) override;
+	void ResumedMarker(const int64_t milliseconds, const int64_t pauselength_ms) override;
 	void TextMarker(const std::string text) override;
 };

--- a/OutputFormat/OutputFormat.SRT.cpp
+++ b/OutputFormat/OutputFormat.SRT.cpp
@@ -15,18 +15,16 @@ OutputFormatSRT::OutputFormatSRT(const InfoWriterSettings &settings, const std::
 {
 }
 
-std::string OutputFormatSRT::SecsToHMSString(const int64_t totalseconds) const
+std::string OutputFormatSRT::MillisToHMSString(const int64_t totalmilliseconds) const
 {
+	int64_t totalseconds = totalmilliseconds / 1000;
 	uint32_t hr = (uint32_t)trunc(totalseconds / 60.0 / 60.0);
 	uint32_t min = (uint32_t)trunc(totalseconds / 60.0) - (hr * 60);
 	uint32_t sec = totalseconds % 60;
-
-	std::string format = "%02d:%02d:%02d,000";
-	std::string replacement = "\t";
-	format += "\0\0\0\0";
+	uint32_t zzz = totalmilliseconds % 1000;
 
 	char buffer[1024];
-	sprintf(&buffer[0], format.c_str(), hr, min, sec);
+	sprintf(&buffer[0], "%02d:%02d:%02d,%03d", hr, min, sec, zzz);
 
 	return buffer;
 }
@@ -48,7 +46,7 @@ void OutputFormatSRT::WriteGFStringToFile(const std::string filename, const std:
 	Writer.close();
 }
 
-void OutputFormatSRT::WriteLines(const int64_t timestamp, const std::string text)
+void OutputFormatSRT::WriteLines(const int64_t milliseconds, const std::string text)
 {
 	char crlf[] = GFNATIVENEXTLINE;
 
@@ -56,7 +54,7 @@ void OutputFormatSRT::WriteLines(const int64_t timestamp, const std::string text
 	sprintf(&buffer[0], "%d", this->subtitleCounter);
 
 	std::string line1 = buffer;
-	std::string line2 = SecsToHMSString(timestamp) + " --> " + SecsToHMSString(timestamp + 5);
+	std::string line2 = MillisToHMSString(milliseconds) + " --> " + MillisToHMSString(milliseconds + 5000);
 
 	WriteGFStringToFile(currentFilename, line1 + crlf);
 	WriteGFStringToFile(currentFilename, line2 + crlf);
@@ -79,34 +77,34 @@ void OutputFormatSRT::Start()
 	this->subtitleCounter++;
 }
 
-void OutputFormatSRT::Stop(const int64_t timestamp)
+void OutputFormatSRT::Stop(const int64_t milliseconds)
 {
 	std::string timestr =
 		Groundfloor::TimestampToStr(c_TimestampNotation_SRT, Groundfloor::GetTimestamp())->getValue();
 	std::string line = "STOP @ " + timestr;
-	WriteLines(timestamp, line);
+	WriteLines(milliseconds, line);
 
 	this->subtitleCounter++;
 }
 
-void OutputFormatSRT::HotkeyMarker(const int64_t timestamp, const std::string text)
+void OutputFormatSRT::HotkeyMarker(const int64_t milliseconds, const std::string text)
 {
-	WriteLines(timestamp, text);
+	WriteLines(milliseconds, text);
 
 	this->subtitleCounter++;
 }
 
-void OutputFormatSRT::ScenechangeMarker(const int64_t timestamp, const std::string scenename)
+void OutputFormatSRT::ScenechangeMarker(const int64_t milliseconds, const std::string scenename)
 {
-	WriteLines(timestamp, scenename);
+	WriteLines(milliseconds, scenename);
 
 	this->subtitleCounter++;
 }
 
-void OutputFormatSRT::PausedMarker([[maybe_unused]] const int64_t timestamp) {}
+void OutputFormatSRT::PausedMarker([[maybe_unused]] const int64_t milliseconds) {}
 
-void OutputFormatSRT::ResumedMarker([[maybe_unused]] const int64_t timestamp,
-				    [[maybe_unused]] const int64_t pauselength)
+void OutputFormatSRT::ResumedMarker([[maybe_unused]] const int64_t milliseconds,
+				    [[maybe_unused]] const int64_t pauselength_ms)
 {
 }
 

--- a/OutputFormat/OutputFormat.SRT.h
+++ b/OutputFormat/OutputFormat.SRT.h
@@ -11,17 +11,17 @@ private:
 	int subtitleCounter;
 	bool canAppend;
 	void WriteGFStringToFile(const std::string filename, const std::string text) const;
-	std::string SecsToHMSString(const int64_t totalseconds) const;
-	void WriteLines(const int64_t timestamp, const std::string text);
+	std::string MillisToHMSString(const int64_t totalmilliseconds) const;
+	void WriteLines(const int64_t milliseconds, const std::string text);
 
 public:
 	OutputFormatSRT(const InfoWriterSettings &settings, const std::string filename);
 
 	void Start() override;
-	void Stop(const int64_t timestamp) override;
-	void HotkeyMarker(const int64_t timestamp, const std::string text) override;
-	void ScenechangeMarker(const int64_t timestamp, const std::string scenename) override;
-	void PausedMarker(const int64_t timestamp) override;
-	void ResumedMarker(const int64_t timestamp, const int64_t pauselength) override;
+	void Stop(const int64_t milliseconds) override;
+	void HotkeyMarker(const int64_t milliseconds, const std::string text) override;
+	void ScenechangeMarker(const int64_t milliseconds, const std::string scenename) override;
+	void PausedMarker(const int64_t milliseconds) override;
+	void ResumedMarker(const int64_t milliseconds, const int64_t pauselength_ms) override;
 	void TextMarker(const std::string text) override;
 };

--- a/tests/stubs/util/base.h
+++ b/tests/stubs/util/base.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <cstdarg>
+
+#define LOG_ERROR 100
+#define LOG_WARNING 200
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline void blog([[maybe_unused]] int log_level, [[maybe_unused]] const char *format, ...) {}
+
+#ifdef __cplusplus
+}
+#endif

--- a/tests/stubs/util/platform.h
+++ b/tests/stubs/util/platform.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <cstdint>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+uint64_t os_gettime_ns(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/tests/test_filename_format.cpp
+++ b/tests/test_filename_format.cpp
@@ -12,26 +12,29 @@ static InfoWriter make_writer(const std::string &filename)
 	return writer;
 }
 
-// Issue #82: invalid strftime specifiers crash OBS because
-// Groundfloor::TimestampToStr throws std::runtime_error and
-// InfoWriter::InitCurrentFilename does not catch it.
+// Issue #82: invalid strftime specifiers used to crash OBS because
+// Groundfloor::TimestampToStr throws std::runtime_error.
+// Now InitCurrentFilename catches it and falls back gracefully.
 
-TEST_CASE("Invalid strftime specifier %s in filename throws", "[filename][issue82]")
+TEST_CASE("Invalid strftime specifier %s in filename does not crash", "[filename][issue82]")
 {
 	auto writer = make_writer("./log %s.txt");
-	REQUIRE_THROWS_AS(writer.MarkStart(imtStream), std::runtime_error);
+	REQUIRE_NOTHROW(writer.MarkStart(imtStream));
+	writer.MarkStop(imtStream);
 }
 
-TEST_CASE("Invalid strftime specifier %k in filename throws", "[filename][issue82]")
+TEST_CASE("Invalid strftime specifier %k in filename does not crash", "[filename][issue82]")
 {
 	auto writer = make_writer("./log %k.txt");
-	REQUIRE_THROWS_AS(writer.MarkStart(imtStream), std::runtime_error);
+	REQUIRE_NOTHROW(writer.MarkStart(imtStream));
+	writer.MarkStop(imtStream);
 }
 
-TEST_CASE("Incomplete % at end of filename throws", "[filename][issue82]")
+TEST_CASE("Incomplete % at end of filename does not crash", "[filename][issue82]")
 {
 	auto writer = make_writer("log %");
-	REQUIRE_THROWS_AS(writer.MarkStart(imtStream), std::runtime_error);
+	REQUIRE_NOTHROW(writer.MarkStart(imtStream));
+	writer.MarkStop(imtStream);
 }
 
 TEST_CASE("Valid strftime specifiers in filename do not throw", "[filename]")

--- a/tests/test_filename_format.cpp
+++ b/tests/test_filename_format.cpp
@@ -1,0 +1,51 @@
+#include <catch2/catch_test_macros.hpp>
+#include "InfoWriter.h"
+#include <filesystem>
+#include <stdexcept>
+
+static InfoWriter make_writer(const std::string &filename)
+{
+	InfoWriter writer;
+	auto *settings = writer.GetSettings();
+	settings->SetFilename(filename);
+	settings->SetFormat("%d:%02d:%02d");
+	return writer;
+}
+
+// Issue #82: invalid strftime specifiers crash OBS because
+// Groundfloor::TimestampToStr throws std::runtime_error and
+// InfoWriter::InitCurrentFilename does not catch it.
+
+TEST_CASE("Invalid strftime specifier %s in filename throws", "[filename][issue82]")
+{
+	auto writer = make_writer("./log %s.txt");
+	REQUIRE_THROWS_AS(writer.MarkStart(imtStream), std::runtime_error);
+}
+
+TEST_CASE("Invalid strftime specifier %k in filename throws", "[filename][issue82]")
+{
+	auto writer = make_writer("./log %k.txt");
+	REQUIRE_THROWS_AS(writer.MarkStart(imtStream), std::runtime_error);
+}
+
+TEST_CASE("Incomplete % at end of filename throws", "[filename][issue82]")
+{
+	auto writer = make_writer("log %");
+	REQUIRE_THROWS_AS(writer.MarkStart(imtStream), std::runtime_error);
+}
+
+TEST_CASE("Valid strftime specifiers in filename do not throw", "[filename]")
+{
+	auto writer = make_writer("/tmp/test_infowriter_valid_%Y-%m-%d_%H%M%S.txt");
+	REQUIRE_NOTHROW(writer.MarkStart(imtStream));
+	writer.MarkStop(imtStream);
+}
+
+TEST_CASE("Filename without specifiers does not throw", "[filename]")
+{
+	std::string tmpfile = "/tmp/test_infowriter_plain.txt";
+	auto writer = make_writer(tmpfile);
+	REQUIRE_NOTHROW(writer.MarkStart(imtStream));
+	writer.MarkStop(imtStream);
+	std::filesystem::remove(tmpfile);
+}

--- a/tests/test_format_utils.cpp
+++ b/tests/test_format_utils.cpp
@@ -1,0 +1,96 @@
+#include <catch2/catch_test_macros.hpp>
+#include "FormatUtils.h"
+
+TEST_CASE("Format zero milliseconds", "[format]")
+{
+	REQUIRE(FormatMillisToHMS("%d:%02d:%02d", 0) == "0:00:00");
+}
+
+TEST_CASE("Format hours minutes seconds", "[format]")
+{
+	// 1h 23m 45s = 5025000ms
+	int64_t ms = 1 * 3600000 + 23 * 60000 + 45 * 1000;
+	REQUIRE(FormatMillisToHMS("%d:%02d:%02d", ms) == "1:23:45");
+}
+
+TEST_CASE("Format with milliseconds component", "[format]")
+{
+	int64_t ms = 1 * 3600000 + 23 * 60000 + 45 * 1000 + 678;
+	REQUIRE(FormatMillisToHMS("%d:%02d:%02d.%03d", ms) == "1:23:45.678");
+}
+
+TEST_CASE("Format with zero-padded hours", "[format]")
+{
+	int64_t ms = 5 * 60000 + 30 * 1000;
+	REQUIRE(FormatMillisToHMS("%02d:%02d:%02d", ms) == "00:05:30");
+}
+
+TEST_CASE("Format with tab replacement", "[format]")
+{
+	int64_t ms = 60 * 1000;
+	REQUIRE(FormatMillisToHMS("%d\\t%02d\\t%02d", ms) == "0\t01\t00");
+}
+
+TEST_CASE("Format milliseconds only partially used", "[format]")
+{
+	int64_t ms = 500;
+	REQUIRE(FormatMillisToHMS("%d:%02d:%02d.%03d", ms) == "0:00:00.500");
+}
+
+TEST_CASE("Format large duration", "[format]")
+{
+	// 10h 0m 0s
+	int64_t ms = 10 * 3600000;
+	REQUIRE(FormatMillisToHMS("%d:%02d:%02d", ms) == "10:00:00");
+}
+
+TEST_CASE("Format with %s returns raw format", "[format]")
+{
+	REQUIRE(FormatMillisToHMS("%s", 0) == "%s");
+}
+
+TEST_CASE("Format with %n returns raw format", "[format]")
+{
+	REQUIRE(FormatMillisToHMS("%d:%02d:%02d %n", 5000) == "%d:%02d:%02d %n");
+}
+
+TEST_CASE("Format with %p returns raw format", "[format]")
+{
+	REQUIRE(FormatMillisToHMS("%p", 0) == "%p");
+}
+
+TEST_CASE("Empty format does not crash", "[format]")
+{
+	REQUIRE_NOTHROW(FormatMillisToHMS("", 5000));
+}
+
+TEST_CASE("Format with no specifiers returns literal", "[format]")
+{
+	REQUIRE(FormatMillisToHMS("hello", 5000) == "hello");
+}
+
+TEST_CASE("Format with 5 specifiers returns raw format", "[format]")
+{
+	std::string fmt = "%d:%02d:%02d.%03d.%d";
+	REQUIRE(FormatMillisToHMS(fmt, 5000) == fmt);
+}
+
+TEST_CASE("Count specifiers with 3 specifiers", "[format]")
+{
+	REQUIRE(CountFormatSpecifiers("%d:%02d:%02d") == 3);
+}
+
+TEST_CASE("Count specifiers with 4 specifiers", "[format]")
+{
+	REQUIRE(CountFormatSpecifiers("%d:%02d:%02d.%03d") == 4);
+}
+
+TEST_CASE("Count specifiers with 5 specifiers", "[format]")
+{
+	REQUIRE(CountFormatSpecifiers("%d:%02d:%02d.%03d.%d") == 5);
+}
+
+TEST_CASE("Count specifiers ignores literal percent", "[format]")
+{
+	REQUIRE(CountFormatSpecifiers("%%d:%02d:%02d") == 2);
+}


### PR DESCRIPTION
## Summary
- Use OBS-native `os_gettime_ns()` for elapsed time tracking instead of `Groundfloor::GetTimestamp()`, giving millisecond precision synced with OBS's internal clock
- IOutputFormat interface timestamps now represent milliseconds — SRT gets real millisecond display (was hardcoded `,000`), EDL gets centiseconds (was hardcoded `00`)
- Add file rename on recording stop using `obs_frontend_get_last_recording()` to match the actual recording filename when sync option is enabled
- Add live previews in settings UI for both Format and Logfile fields
- Validate format strings: reject unsafe specifiers (`%s`, `%n`, `%p`) and too many specifiers (max 4: hr, min, sec, ms)
- Catch invalid strftime in filename formatting with `blog()` fallback instead of crashing OBS (fixes #82)
- Extract shared `FormatMillisToHMS()` into `FormatUtils` to deduplicate formatting logic
- Fix `StreamStarted` not being set to `true` on stream start
- Add test infrastructure: `DummyPlatform.cpp` and `tests/stubs/` for building tests without libobs
- Add format validation tests (22 test cases total)

## Test plan
- [x] Verify millisecond precision in output files (default, CSV, SRT, EDL formats)
- [x] Verify SRT output shows real milliseconds instead of `,000`
- [x] Test Format field preview updates live as user types
- [x] Test Logfile field preview shows formatted filename or error for invalid specifiers
- [x] Test `%s` in Logfile field shows error instead of crashing
- [x] Test `%d:%02d:%02d.%03d.%d` (5 specifiers) in Format field shows error
- [x] Test recording file rename when "Sync with video file name and path" is enabled
- [x] Run unit tests: `cmake --build build_test && build_test/test_infowriter`

🤖 Generated with [Claude Code](https://claude.com/claude-code)